### PR TITLE
Singleplayer Crash Fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Gradle Package
+
+on:
+  release:
+    types: [created]
+  pull_request:
+  workflow_dispatch:
+  push:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        server-id: github
+        settings-path: ${{ github.workspace }}
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+    - name: Build with Gradle
+      run: ./gradlew build
+
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: artifacts
+        path: versions/**/build/libs/
+
+    - name: Clean Gradle
+      run: ./gradlew clean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build --no-daemon
 
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v4
@@ -38,4 +38,4 @@ jobs:
         path: versions/**/build/libs/
 
     - name: Clean Gradle
-      run: ./gradlew clean
+      run: ./gradlew clean --no-daemon

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 mod_name=Freelook
 mod_id=freelook
-mod_version=2.0.0
+mod_version=2.0.1
 mod_archives_name=Freelook
 
 # Gradle Configuration -- DO NOT TOUCH THESE VALUES.

--- a/src/main/java/me/syz/freelook/mixins/ModListMixin.java
+++ b/src/main/java/me/syz/freelook/mixins/ModListMixin.java
@@ -12,12 +12,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.List;
 import java.util.Map;
 
-@Mixin(FMLHandshakeMessage.ModList.class)
+@Mixin(FMLHandshakeMessage.ModList.class, remap = false)
 public class ModListMixin {
-    @Shadow(remap = false) private Map<String,String> modTags;
+    @Shadow private Map<String,String> modTags;
 
-    @Inject(method = "<init>(Ljava/util/List;)V", at = @At("RETURN"), remap = false)
+    @Inject(method = "<init>(Ljava/util/List;)V", at = @At("RETURN"))
     private void removeMod(List<ModContainer> modList, CallbackInfo ci) {
-        this.modTags.keySet().removeIf(key -> key.equals(FreelookMod.MODID));
+        if (!Minecraft.getMinecraft().isIntegratedServerRunning())
+            this.modTags.remove(FreelookMod.MODID);
     }
 }

--- a/src/main/java/me/syz/freelook/mixins/ModListMixin.java
+++ b/src/main/java/me/syz/freelook/mixins/ModListMixin.java
@@ -1,6 +1,7 @@
 package me.syz.freelook.mixins;
 
 import me.syz.freelook.FreelookMod;
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.network.handshake.FMLHandshakeMessage;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/java/me/syz/freelook/mixins/ModListMixin.java
+++ b/src/main/java/me/syz/freelook/mixins/ModListMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.List;
 import java.util.Map;
 
-@Mixin(FMLHandshakeMessage.ModList.class, remap = false)
+@Mixin(value = FMLHandshakeMessage.ModList.class, remap = false)
 public class ModListMixin {
     @Shadow private Map<String,String> modTags;
 


### PR DESCRIPTION
Fix a crash with the ModList Handshake

```
[23:14:22] [Netty Server IO #1/INFO] [FML]: Client attempting to join with 4 mods : Forge@11.15.1.2318,mcp@9.19,FML@8.0.99.99,oneconfig@0.2.2-alpha223
[23:14:22] [Netty Server IO #1/INFO] [FML]: Attempting connection with missing mods [freelook] at CLIENT
[23:14:22] [Netty Server IO #1/INFO] [FML]: Rejecting connection CLIENT: [FMLMod:freelook{2.0.0}]
[23:14:22] [Netty Local Client IO #0/INFO] [FML]: Unexpected packet during modded negotiation - assuming vanilla or keepalives : net.minecraft.network.play.server.S40PacketDisconnect
[23:14:22] [Server thread/INFO]: CatboyGhosty lost connection: TextComponent{text='Mod rejections [FMLMod:freelook{2.0.0}]', siblings=[], style=Style{hasParent=false, color=null, bold=null, italic=null, underlined=null, obfuscated=null, clickEvent=null, hoverEvent=null, insertion=null}}
```

- Disabled the hider in singleplayer
- Added a lil workflow :)
- Changed version to 2.0.1

Also you should move the repo to your org, and change the mentions 😊👍 