### PR TITLE
Fixed Pitch Lock Logic

### DIFF
--- a/src/main/kotlin/com/github/chromaticforge/freelook/Freelook.kt
+++ b/src/main/kotlin/com/github/chromaticforge/freelook/Freelook.kt
@@ -69,7 +69,7 @@ object Freelook {
         cameraYaw += yaw
 
         if (FreelookConfig.invertPitch) pitch = -pitch
-        if (FreelookConfig.lockPitch) pitch = pitch.coerceIn(-90f, 90f)
         cameraPitch += pitch
+        if (FreelookConfig.lockPitch) cameraPitch = cameraPitch.coerceIn(-90f, 90f)
     }
 }


### PR DESCRIPTION
Refactors the pitch clamping logic to apply after adding the pitch delta to cameraPitch, ensuring the actual camera angle is correctly constrained instead of the pitch delta